### PR TITLE
Implement user models with JPA and basic registration with pass encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.flywaydb:flyway-core' // Flyway core dependency
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'org.flywaydb:flyway-database-postgresql:10.18.0' // Flyway PostgreSQL dependency

--- a/src/main/java/com/activecourses/upwork/UpworkApplication.java
+++ b/src/main/java/com/activecourses/upwork/UpworkApplication.java
@@ -2,8 +2,10 @@ package com.activecourses.upwork;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class UpworkApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/activecourses/upwork/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/activecourses/upwork/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.activecourses.upwork.exception;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<String> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        return new ResponseEntity<>("Email already exists", HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/activecourses/upwork/model/Role.java
+++ b/src/main/java/com/activecourses/upwork/model/Role.java
@@ -1,0 +1,47 @@
+package com.activecourses.upwork.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "roles", indexes = {
+        @Index(name = "idx_roles_name", columnList = "name")
+})
+@EntityListeners(AuditingEntityListener.class)
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @ManyToMany(mappedBy = "roles")
+    @JsonIgnore
+    private List<User> users;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/java/com/activecourses/upwork/model/User.java
+++ b/src/main/java/com/activecourses/upwork/model/User.java
@@ -1,0 +1,118 @@
+package com.activecourses.upwork.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users", indexes = {
+        @Index(name = "idx_users_email", columnList = "email")
+})
+public class User implements UserDetails, Principal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    @Size(max = 255)
+    @NotBlank
+    private String firstName;
+
+    @Column(nullable = false)
+    @Size(max = 255)
+    @NotBlank
+    private String lastName;
+
+    @Column(unique = true, nullable = false)
+    @Email
+    @NotBlank
+    private String email;
+
+    @Column(nullable = false)
+    @Size(min = 8)
+    @NotBlank
+    private String password;
+
+    private boolean accountLocked;
+
+    private boolean accountEnabled;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private List<Role> roles;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(insertable = false)
+    private LocalDateTime lastModifiedAt;
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority(role.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return !accountLocked;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return !accountLocked;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return !accountLocked;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return accountEnabled;
+    }
+}

--- a/src/main/java/com/activecourses/upwork/repository/RoleRepository.java
+++ b/src/main/java/com/activecourses/upwork/repository/RoleRepository.java
@@ -1,0 +1,9 @@
+package com.activecourses.upwork.repository;
+
+import com.activecourses.upwork.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Integer> {
+}

--- a/src/main/java/com/activecourses/upwork/repository/UserRepository.java
+++ b/src/main/java/com/activecourses/upwork/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.activecourses.upwork.repository;
+
+import com.activecourses.upwork.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/activecourses/upwork/security/SecurityConfig.java
+++ b/src/main/java/com/activecourses/upwork/security/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.activecourses.upwork.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(10);
+    }
+}

--- a/src/main/java/com/activecourses/upwork/service/UserService.java
+++ b/src/main/java/com/activecourses/upwork/service/UserService.java
@@ -1,0 +1,23 @@
+package com.activecourses.upwork.service;
+
+import com.activecourses.upwork.model.User;
+import com.activecourses.upwork.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public void registerUser(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+        userRepository.save(user);
+    }
+}

--- a/src/test/java/com/activecourses/upwork/service/UserServiceTest.java
+++ b/src/test/java/com/activecourses/upwork/service/UserServiceTest.java
@@ -1,0 +1,54 @@
+package com.activecourses.upwork.service;
+
+import com.activecourses.upwork.model.User;
+import com.activecourses.upwork.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void registerUser() {
+        User user = new User();
+        user.setFirstName("Ahmed");
+        user.setLastName("Muhammed");
+        user.setEmail("am0103738@gmail.com");
+        user.setPassword("password123");
+
+        // Verify that the UserService correctly calls the passwordEncoder.encode method
+        // Just simulate the behavior of the password encoder without actually performing the encoding
+        when(passwordEncoder.encode(any(String.class))).thenReturn("encodedPassword");
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        when(userRepository.findByEmail("am0103738@gmail.com")).thenReturn(Optional.of(user));
+
+        userService.registerUser(user);
+
+        verify(userRepository, times(1)).save(user);
+        assertNotNull(userRepository.findByEmail("am0103738@gmail.com"));
+        assertEquals("encodedPassword", user.getPassword());
+    }
+}


### PR DESCRIPTION
closes #6 

This pull request implements the initial setup for user models and basic registration with pass encoding, including:

- **User and Role Entities**: Added entities to represent users and their roles.
  
- **User Registration**: Implemented a basic registration method that encodes passwords before saving the user.

- **Unit Test**: Created an initial unit test for the user registration service.

**Note**: This PR is part of the user authentication implementation. Another team member will integrate JWT and Spring Security.